### PR TITLE
add: customizable-hotkey-plus-code-refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,32 @@
-![](https://i.imgur.com/MVR68qM.jpg)
+![](https://i.imgur.com/DXMg8ha.png)
 
 ## What the Extension Does
 
--   Adds a "Search on Nyaa" Button to Anime and Manga pages
-    -   Sites: **[MyAnimeList](https://i.imgur.com/1hymaOS.png), [AniList](https://i.imgur.com/DtNugQF.png), [Kitsu](https://i.imgur.com/TVKqRcK.png), [Anime-Planet](https://i.imgur.com/zohAYbs.png), [AnimeNewsNetwork](https://i.imgur.com/xOYS17r.png), [AniDB](https://i.imgur.com/pRDcUVh.png), [LiveChart](https://imgur.com/plZxpBN)**
--   Search Parameters can be changed and saved in the [Extension Popup window](https://i.imgur.com/bzaChNf.png)
+-   Adds a "Search on Nyaa" Button to Anime and Manga database pages
+    -   Individual: **[MyAnimeList](https://i.imgur.com/IXJ7XuK.png), [AniList](https://i.imgur.com/9xhFu5q.jpeg), [Anime-Planet](https://i.imgur.com/sGsl0Bw.png), [AnimeNewsNetwork](https://i.imgur.com/xXvJXHC.png), [LiveChart](https://i.imgur.com/VyIWtLC.png), [AniDB](https://i.imgur.com/DqSkmOg.jpeg), [Kitsu](https://i.imgur.com/CN2kh4C.jpeg)**
+    -   Card-type: _**MyAnimeList** ([Season](https://i.imgur.com/7M4hr0z.png), [Genre](https://i.imgur.com/SklbImH.png)), **LiveChart** ([Season](https://i.imgur.com/wvLOp8N.jpeg), [Franchises](https://i.imgur.com/wcNv1JC.jpeg))_
+-   Extension settings can be customized and saved in the [Extension Popup window](https://i.imgur.com/ymIkV63.png)
 
-    -   For Manga pages, the Category setting will search for the "Literature" equivalent
-    -   All tabs with a supported website currently open will automatically refresh on Save
+    -   The primary settings page is used to change Nyaa search parameters
+        -   For Manga pages, the Category setting will search for the "Literature" equivalent
+    -   The secondary page is used to change extension behavior _(accessed by clicking the cog icon)_
+        -   The Hotkey can be used to activate the button _(even when "Hide Button" is enabled)_
+    -   All browser tabs containing a supported website will refresh after pressing the save button
 
--   By default the search will include both the Japanese(Romaji) & English titles — if they exist, and they are different
-    -   the search will also add the base titles, if they include: ("Season"|"Part"|": "|" - ")
-        -   for example, clicking the button on [Shingeki no Kyojin Season 3 Part 2](https://myanimelist.net/anime/38524/Shingeki_no_Kyojin_Season_3_Part_2) will return the search query:
-        -   _"Shingeki no Kyojin Season 3 Part 2"|"Attack on Titan Season 3 Part 2"|"Shingeki no Kyojin"|"Attack on Titan"_
-    -   _**additional "Query" types are available**: the Default combines both "Exact" and "Base"._
-        -   Fuzzy: Searches for the site's default title only, without quotes ~ allows fuzzy matching
-        -   Exact: Japanese and English full titles ~ searches for exact title names as written
-        -   Base: Japanese and English base titles ~ searches with Seasons and Parts removed
+-   Additional Query types are available: _"Default" combines "Exact" and "Base"_.
+
+    -   Fuzzy: Searches for the site's default title only, without quotes ~ allows fuzzy matching
+    -   Exact: Japanese and English full titles ~ searches for exact title names as written
+    -   Base: Japanese and English base titles ~ searches with Seasons and Parts removed
+
+-   "Default" search example: clicking the button on [Shingeki no Kyojin Season 3 Part 2](https://myanimelist.net/anime/38524/Shingeki_no_Kyojin_Season_3_Part_2) will search Nyaa for:
+    -   _"Shingeki no Kyojin Season 3 Part 2"|"Attack on Titan Season 3 Part 2"|"Shingeki no Kyojin"|"Attack on Titan"_
 
 # Firefox - [Extension Page](https://addons.mozilla.org/en-US/firefox/addon/nyaa-linker/)
 
 # Chrome - ~~Extension Page~~
 
-> I don't have a Chrome Developer Account, Chrome Users will need to manually install the Extension for now
+> I don't have a Chrome Developer Account, Chrome Users will need to manually install the Extension
 
 -   Download Chrome.zip from the [Latest Release](https://github.com/Metacor/nyaa-linker/releases)
 -   [Enable "Developer mode" in Chrome](https://i.imgur.com/h7kvj1h.png)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nyaa-linker",
-    "version": "1.3.0",
+    "version": "2.0.0",
     "description": "Adds a button to Anime and Manga database websites that opens a relevant Nyaa search",
     "scripts": {
         "zip": "npm run firefox && npm run chrome",

--- a/src/background.js
+++ b/src/background.js
@@ -1,8 +1,7 @@
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-    const cringeSites = ['kitsu.io/*', 'anilist.co/*'];
-    const skip = ['/episodes', '/chapters', '/characters', '/watch', '/reactions', '/franchise', '/staff', '/reviews', '/stats', '/social'];
-    for (const site in cringeSites) {
-        if (changeInfo.status === 'complete' && tab.url.match(cringeSites[site]) && !skip.some((e) => tab.url.includes(e))) {
+    const manifestSites = chrome.runtime.getManifest().content_scripts[0].matches;
+    if (changeInfo.status === 'complete') {
+        if (manifestSites.some((site) => tab.url.match(site.split('*://*.').pop()))) {
             chrome.tabs.sendMessage(tabId, { type: 'tabUpdated', url: tab.url });
         }
     }
@@ -18,6 +17,10 @@ const defaultSettings = () => {
             query_setting: 'default',
             sort_setting: 'seeders',
             order_setting: 'desc',
+            hide_button_setting: false,
+            focus_setting: false,
+            hotkey_key_setting: '',
+            hotkey_modifier_setting: '',
         },
     });
 };

--- a/src/main.js
+++ b/src/main.js
@@ -1,323 +1,306 @@
-chrome.runtime.onMessage.addListener((request) => request.type === 'tabUpdated' && searchNyaa());
+chrome.runtime.onMessage.addListener((request) => request.type === 'tabUpdated' && init());
+let activeListener;
 
-const awaitLoadOf = (selector) => {
-    return new Promise((resolve) => {
-        const mutObs = new MutationObserver(() => {
-            if (document.querySelector(selector)) {
-                resolve(document.querySelector(selector));
-                mutObs.disconnect();
-            }
+async function init() {
+    const loadUserSettings = await new Promise((resolve) => {
+        chrome.storage.sync.get('settings', (res) => {
+            resolve(res);
         });
-        mutObs.observe(document.body, { childList: true, subtree: true });
     });
-};
 
-const searchNyaa = () => {
+    const settings = loadUserSettings.settings;
+    searchNyaa(settings);
+}
+
+function searchNyaa(settings) {
     const domain = window.location.href;
     const media = window.location.pathname.includes('manga') ? 'manga' : 'anime';
+    let queryType = settings.query_setting;
+    let titleJap, titleEng, btn, btnSpace, cardType;
 
-    chrome.storage.sync.get('settings', (load) => {
-        const filter = load.settings.filter_setting;
-        let category = load.settings.category_setting;
-        const queryType = load.settings.query_setting;
-        const sort = load.settings.sort_setting;
-        const order = load.settings.order_setting;
-
-        if (media === 'manga') {
-            const searchManga = (cat) => {
-                const categories = { '0_0': '3_0', '1_2': '3_1', '1_3': '3_2', '1_4': '3_3' };
-                return categories[cat];
-            };
-            category = searchManga(category);
-        }
-
-        let titleJap, titleEng, btnSpace, btn;
-        const createBtn = () => {
-            btn = btnSpace.appendChild(document.createElement('a'));
-            btn.classList.add('nyaaBtn');
+    if (media === 'manga') {
+        const searchManga = (cat) => {
+            const categories = { '0_0': '3_0', '1_2': '3_1', '1_3': '3_2', '1_4': '3_3' };
+            return categories[cat];
         };
+        settings.category_setting = searchManga(settings.category_setting);
+    }
 
-        switch (true) {
-            case domain.includes(`myanimelist.net`):
-                const malMain = new RegExp(`myanimelist\\.net/${media}/\\d+`);
-                if (malMain.test(domain)) {
-                    const engCheck = document.querySelector('.title-english');
-                    engCheck && (titleEng = engCheck.textContent);
+    function createSearch(query) {
+        if (btn) {
+            !btn.title && (btn.textContent = 'Search on Nyaa');
+            btn.href = `https://nyaa.si/?f=${settings.filter_setting}&c=${settings.category_setting}&q=${query}&s=${settings.sort_setting}&o=${settings.order_setting}`;
+            btn.target = '_blank';
+        }
+    }
 
-                    if (media === 'manga') {
-                        const titleElm = document.querySelector('[itemprop="name"]');
-                        titleJap = titleElm.textContent;
-                        if (engCheck) {
-                            (engCheck.textContent = ''), (titleJap = titleElm.textContent), (engCheck.textContent = titleEng);
-                        }
-                    } else {
-                        titleJap = document.querySelector('.title-name > strong').textContent;
+    function createBtn(btnSpace) {
+        !cardType && document.querySelector('.nyaaBtn') && document.querySelector('.nyaaBtn').remove();
+        btn = btnSpace.appendChild(document.createElement('a'));
+        btn.classList.add('nyaaBtn');
+        settings.hide_button_setting && (btn.style.display = 'none');
+    }
+
+    if (!activeListener && settings.hotkey_key_setting) {
+        document.addEventListener('keydown', function (e) {
+            if (
+                (btn && e[settings.hotkey_modifier_setting] && e.key.toLowerCase() == settings.hotkey_key_setting) ||
+                (btn && settings.hotkey_modifier_setting === '' && !e.ctrlKey && !e.shiftKey && !e.altKey && e.key == settings.hotkey_key_setting)
+            ) {
+                document.querySelector('.nyaaBtn').dispatchEvent(new MouseEvent('click', { ctrlKey: settings.focus_setting }));
+                e.preventDefault();
+            }
+        });
+        activeListener = true;
+    }
+
+    switch (true) {
+        case domain.includes(`myanimelist.net`):
+            const malMain = new RegExp(`myanimelist\\.net/${media}/\\d+`);
+            if (malMain.test(domain)) {
+                const engCheck = document.querySelector('.title-english');
+                engCheck && (titleEng = engCheck.textContent);
+
+                if (media === 'manga') {
+                    const titleElm = document.querySelector('[itemprop="name"]');
+                    titleJap = titleElm.textContent;
+                    if (engCheck) {
+                        (engCheck.textContent = ''), (titleJap = titleElm.textContent), (engCheck.textContent = titleEng);
                     }
-
-                    btnSpace = document.getElementById('broadcast-block')
-                        ? document.getElementById('broadcast-block')
-                        : document.querySelector('.leftside').children[0];
-                    createBtn();
-                    btn.style.marginTop = '4px';
-                    btn.classList.add('left-info-block-broadcast-button');
+                } else {
+                    titleJap = document.querySelector('.title-name').textContent;
                 }
-                if (domain.includes(`/genre`) || domain.includes(`/season`) || domain.includes('/magazine')) {
-                    for (const card of document.querySelectorAll('.seasonal-anime')) {
-                        titleJap = card.querySelector('.title').innerText;
 
-                        btnSpace = card.querySelector('.broadcast');
-                        createBtn(btnSpace);
-                        btn.style.background = 'url(https://i.imgur.com/9Fr2BRG.png) center/20px no-repeat';
-                        btn.style.padding = '0 11px';
-                        btn.title = 'Search on Nyaa';
-                        btn.href = `https://nyaa.si/?f=${filter}&c=${category}&q=${titleJap}&s=${sort}&o=${order}`;
-                        btn.target = '_blank';
-                    }
+                document.getElementById('broadcast-block')
+                    ? (btnSpace = document.getElementById('broadcast-block'))
+                    : (btnSpace = document.querySelector('.leftside').children[0]);
+                createBtn(btnSpace);
+                btn.style.marginTop = '4px';
+                btn.classList.add('left-info-block-broadcast-button');
+                createSearch(getQuery(titleJap, titleEng, queryType));
+            }
+
+            if (domain.includes(`/genre`) || domain.includes(`/season`) || domain.includes('/magazine')) {
+                for (const card of document.querySelectorAll('.seasonal-anime')) {
+                    cardType = true;
+                    titleJap = card.querySelector('.title h2').innerText;
+                    card.querySelector('.title h3') ? (titleEng = card.querySelector('.title h3').innerText) : (titleEng = undefined);
+
+                    createBtn(card.querySelector('.broadcast'));
+                    btn.style.background = 'url(https://i.imgur.com/9Fr2BRG.png) center/20px no-repeat';
+                    btn.style.padding = '0 11px';
+                    btn.title = 'Search on Nyaa';
+                    createSearch(getQuery(titleJap, titleEng, queryType));
                 }
+            }
+            break;
+
+        case domain.includes(`anime-planet.com/${media}/`) && domain !== `https://www.anime-planet.com/${media}/`:
+            const skipPages = ['all', 'top-', 'recommendations', 'tags'];
+            let skipExtra =
+                media == 'anime' ? ['seasons', 'watch-online', 'studios'] : ['read-online', 'publishers', 'magazines', 'webtoons', 'light-novels'];
+
+            if (skipPages.some((page) => domain.includes(`/${media}/${page}`)) || skipExtra.some((page) => domain.includes(`/${media}/${page}`))) {
                 break;
+            }
 
-            case domain.includes(`anime-planet.com/${media}/`):
-                setTimeout(() => {
-                    const titleMain = document.querySelector('[itemprop=name]').textContent;
-                    const titleAlt = document.getElementsByClassName('aka')[0];
-                    titleEng = titleMain;
-                    titleAlt ? (titleJap = titleAlt.innerText.split(': ').pop()) : (titleJap = titleMain);
+            setTimeout(() => {
+                const titleMain = document.querySelector('[itemprop=name]').textContent;
+                const titleAlt = document.getElementsByClassName('aka')[0];
+                titleEng = titleMain;
+                titleAlt ? (titleJap = titleAlt.innerText.split(': ').pop()) : (titleJap = titleMain);
 
-                    btnSpace = document.querySelector('.mainEntry');
-                    createBtn();
-                    btn.classList.add('button');
-                    const buttons = document.querySelectorAll('.mainEntry > .button');
-                    for (const button in buttons) {
-                        typeof buttons[button] === 'object' && (buttons[button].style.width = '180px');
-                    }
-                }, 50);
-                break;
+                createBtn(document.querySelector('.mainEntry'));
+                btn.classList.add('button');
+                document.querySelectorAll('.mainEntry > .button').forEach((button) => {
+                    typeof button === 'object' && (button.style.width = '180px');
+                });
+                createSearch(getQuery(titleJap, titleEng, queryType));
+            }, 50);
+            break;
 
-            case domain.includes(`animenewsnetwork.com/encyclopedia/${media}.php?id=`):
-                setTimeout(() => {
-                    titleEng = document.getElementById('page_header').innerText.split(' (').shift();
-                    for (const altTitle of document.querySelectorAll('#infotype-2 > .tab')) {
-                        altTitle.textContent.includes('Japanese') && !titleJap && (titleJap = altTitle.textContent.split(' (').shift());
-                    }
-                    !titleJap && titleEng && (titleJap = titleEng);
+        case domain.includes(`animenewsnetwork.com/encyclopedia/${media}.php?id=`):
+            setTimeout(() => {
+                titleEng = document.getElementById('page_header').innerText.split(' (').shift();
+                for (const altTitle of document.querySelectorAll('#infotype-2 > .tab')) {
+                    altTitle.textContent.includes('Japanese') && !titleJap && (titleJap = altTitle.textContent.split(' (').shift());
+                }
+                !titleJap && titleEng && (titleJap = titleEng);
 
-                    btnSpace = document.querySelector('.fright') ? document.querySelector('.fright') : document.querySelector('#big-video');
-                    createBtn();
-                    btn.style.cssText = `
-                        display: flex;
-                        align-items: center;
-                        justify-content: center;
-                        height: 35px;
-                        border-radius: 3px;
-                        background: #2d50a7;
-                        color: #fff;
-                        border: 1px solid black;
-                        text-decoration: none;`;
-                    btnSpace.children[0].tagName === 'TABLE' && (btn.style.marginTop = '4px');
-                }, 50);
-                break;
+                btnSpace = document.querySelector('.fright') ? document.querySelector('.fright') : document.querySelector('#big-video');
+                createBtn(btnSpace);
+                btn.style.cssText = `
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+                    height: 35px;
+                    border-radius: 3px;
+                    background: #2d50a7;
+                    color: #fff;
+                    border: 1px solid black;
+                    text-decoration: none;`;
+                btnSpace.children[0].tagName === 'TABLE' && (btn.style.marginTop = '4px');
+                createSearch(getQuery(titleJap, titleEng, queryType));
+            }, 50);
+            break;
 
-            case domain.includes(`anidb.net/${media}/`):
+        case domain.includes(`anidb.net/${media}/`):
+            const hasID = /anidb\.net\/\w+\/(\d+)/;
+            if (domain.match(hasID)) {
                 titleJap = document.querySelector(".value > [itemprop='name']").textContent;
                 titleEng = document.querySelector(".value > [itemprop='alternateName']").textContent;
 
-                btnContainer = document.querySelector('.resources > .value .english');
-                btnSpace = btnContainer.appendChild(document.createElement('div'));
+                btnSpace = document.querySelector('.resources > .value .english').appendChild(document.createElement('div'));
                 btnSpace.classList.add('icons');
-                createBtn();
+                createBtn(btnSpace);
                 btn.classList.add('i_icon');
                 btn.style.backgroundImage = "url('https://i.imgur.com/YG6H2nF.png')";
                 btn.style.backgroundSize = 'contain';
                 btn.title = 'Search on Nyaa';
-                break;
+                createSearch(getQuery(titleJap, titleEng, queryType));
+            }
+            break;
 
-            case domain.includes(`anilist.co/${media}/`):
-                awaitLoadOf('div.data-set > div.value').then(() => {
-                    const dataList = document.getElementsByClassName('type');
-                    for (const data of dataList) {
-                        const setTitle = data.parentNode.children[1].textContent;
-                        data.textContent.includes('Romaji') && (titleJap = setTitle);
-                        data.textContent.includes('English') && (titleEng = setTitle);
-                    }
+        case domain.includes(`anilist.co/${media}/`):
+            awaitLoadOf('.sidebar .type', 'Romaji', () => {
+                for (const data of document.getElementsByClassName('type')) {
+                    const setTitle = data.parentNode.children[1].textContent;
+                    data.textContent.includes('Romaji') && (titleJap = setTitle);
+                    data.textContent.includes('English') && (titleEng = setTitle);
+                }
 
-                    !titleJap && !titleEng && searchNyaa();
+                createBtn(document.querySelector('.cover-wrap-inner'));
+                btn.style.cssText = `
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+                    height: 35px;
+                    border-radius: 3px;
+                    margin-bottom: 20px;
+                    background: rgb(var(--color-blue));
+                    color: rgb(var(--color-white));`;
+                createSearch(getQuery(titleJap, titleEng, queryType));
+            });
+            break;
 
-                    btnSpace = document.querySelector('.cover-wrap-inner');
-                    document.querySelector('.nyaaBtn') && document.querySelector('.nyaaBtn').remove();
-                    createBtn(btnSpace);
-                    btn.style.cssText = `
-                        display: flex;
-                        align-items: center;
-                        justify-content: center;
-                        height: 35px;
-                        border-radius: 3px;
-                        background: rgb(var(--color-blue));
-                        color: #fff;
-                        margin-bottom: 20px;`;
-                });
-                break;
+        case domain.includes(`kitsu.io/${media}/`):
+            awaitLoadOf('.media--information', 'Japanese (Romaji)', () => {
+                let titleUsa;
+                for (const typeCheck of document.querySelectorAll('.media--information > ul > li')) {
+                    const usaCheck = typeCheck.textContent.includes('English (American)');
+                    const setTitle = typeCheck.getElementsByTagName('span')[0];
+                    typeCheck.textContent.includes('Japanese (Romaji)') && (titleJap = setTitle.textContent);
+                    typeCheck.textContent.includes('English') && !usaCheck && (titleEng = setTitle.textContent);
+                    usaCheck && (titleUsa = setTitle.textContent);
+                }
+                !titleEng && titleUsa && (titleEng = titleUsa);
+                !titleJap && titleEng && (titleJap = titleEng);
 
-            case domain.includes(`kitsu.io/${media}/`):
-                awaitLoadOf('.media--information').then(() => {
-                    let titleUsa;
-                    for (const typeCheck of document.querySelectorAll('.media--information > ul > li')) {
-                        const usaCheck = typeCheck.textContent.includes('English (American)');
-                        const setTitle = typeCheck.getElementsByTagName('span')[0];
-                        typeCheck.textContent.includes('Japanese (Romaji)') && (titleJap = setTitle.textContent);
-                        typeCheck.textContent.includes('English') && !usaCheck && (titleEng = setTitle.textContent);
-                        usaCheck && (titleUsa = setTitle.textContent);
-                    }
+                createBtn(document.querySelector('.library-state'));
+                btn.classList.add('button', 'button--secondary');
+                btn.style.background = '#f5725f';
+                btn.style.marginTop = '10px';
+                createSearch(getQuery(titleJap, titleEng, queryType));
+            });
+            break;
 
-                    !titleEng && titleUsa && (titleEng = titleUsa);
-                    !titleJap && titleEng && (titleJap = titleEng);
-                    !titleJap && !titleEng && searchNyaa();
+        case domain.includes('livechart.me'):
+            if (domain.includes(`livechart.me/${media}/`)) {
+                titleJap = document.querySelector('.grow .text-xl').innerText;
+                titleEng = document.querySelector('.grow .text-lg').innerText;
 
-                    btnSpace = document.querySelector('.entry-state-status > div');
-                    document.querySelector('.nyaaBtn') && document.querySelector('.nyaaBtn').remove();
-                    createBtn();
-                    btn.classList.add('button', 'button--secondary');
-                    btn.style.background = '#f5725f';
-                });
-                break;
+                createBtn(document.querySelector('.lc-poster-col'));
+                btn.classList.add('lc-btn', 'lc-btn-sm', 'lc-btn-outline');
+                createSearch(getQuery(titleJap, titleEng, queryType));
+            } else {
+                let cardSelector, cardSpace;
+                domain.includes('livechart.me/franchises/') ? (cardSelector = '.lc-anime') : (cardSelector = '.anime');
+                domain.includes('livechart.me/franchises/') ? (cardSpace = '.lc-anime-card--related-links') : (cardSpace = '.related-links');
 
-            case domain.includes('livechart.me'):
-                setTimeout(() => {
-                    if (domain.includes(`livechart.me/${media}/`)) {
-                        titleJap = document.querySelector('.grow .text-xl').innerText;
-                        titleEng = document.querySelector('.grow .text-lg').innerText;
+                for (const card of document.querySelectorAll(cardSelector)) {
+                    cardType = true;
+                    titleJap = card.getAttribute('data-romaji');
+                    card.getAttribute('data-english') ? (titleEng = card.getAttribute('data-english')) : (titleEng = undefined);
 
-                        btnSpace = document.querySelector('.lc-poster-col');
-                        createBtn(btnSpace);
-                        btn.classList.add('lc-btn', 'lc-btn-sm', 'lc-btn-outline');
-                    } else if (domain.includes('livechart.me/franchises/')) {
-                        for (const card of document.querySelectorAll('.lc-anime')) {
-                            titleJap = card.getAttribute('data-romaji');
-                            titleEng = card.getAttribute('data-english');
+                    createBtn(card.querySelector(cardSpace));
+                    btn.style.background = 'url(https://i.imgur.com/9Fr2BRG.png) center/20px no-repeat';
+                    btn.style.padding = '15px';
+                    btn.style.margin = 0;
+                    btn.classList.add('action-button');
+                    btn.title = 'Search on Nyaa';
+                    createSearch(getQuery(titleJap, titleEng, queryType));
+                }
+            }
+            break;
+    }
+}
 
-                            let tempQuery;
-                            titleEng == null ? (tempQuery = titleJap) : (tempQuery = `"${titleJap}"|"${titleEng}"`);
+function getQuery(titleJap, titleEng, queryType) {
+    !titleJap && !titleEng && init();
+    query = `"${titleJap}"|"${titleEng}"`;
 
-                            btnSpace = card.querySelector('.lc-anime-card--related-links');
-                            createBtn(btnSpace);
-                            btn.style.background = 'url(https://i.imgur.com/9Fr2BRG.png) center/20px no-repeat';
-                            btn.classList.add('lc-anime-card--related-links--action-button');
-                            btn.title = 'Search on Nyaa';
-                            btn.href = `https://nyaa.si/?f=${filter}&c=${category}&q=${tempQuery}&s=${sort}&o=${order}`;
-                            btn.target = '_blank';
-                        }
-                    } else {
-                        for (const card of document.querySelectorAll('.anime')) {
-                            titleJap = card.getAttribute('data-romaji');
-                            titleEng = card.getAttribute('data-english');
+    if (!titleEng || titleJap.toLowerCase() === titleEng.toLowerCase()) {
+        query = titleJap;
+        return query;
+    } else {
+        let baseJap = getBaseTitle(titleJap);
+        let baseEng = getBaseTitle(titleEng);
 
-                            let tempQuery;
-                            titleEng == null ? (tempQuery = titleJap) : (tempQuery = `"${titleJap}"|"${titleEng}"`);
-
-                            btnSpace = card.querySelector('.related-links');
-                            createBtn(btnSpace);
-                            btn.style.background = 'url(https://i.imgur.com/9Fr2BRG.png) center/20px no-repeat';
-                            btn.classList.add('action-button');
-                            btn.title = 'Search on Nyaa';
-                            btn.href = `https://nyaa.si/?f=${filter}&c=${category}&q=${tempQuery}&s=${sort}&o=${order}`;
-                            btn.target = '_blank';
-                        }
-                    }
-                }, 50);
-                break;
+        if (queryType == 'default') {
+            baseJap == titleJap && baseEng == titleEng ? (query = query) : (query = `"${titleJap}"|"${titleEng}"|"${baseJap}"|"${baseEng}"`);
         }
 
-        awaitLoadOf('.nyaaBtn').then(() => {
-            let query = `"${titleJap}"|"${titleEng}"`;
-            let baseJap = titleJap;
-            let baseEng = titleEng;
+        if (queryType == 'base') {
+            baseJap == baseEng ? (query = query) : (query = `"${baseJap}"|"${baseEng}"`);
+        }
 
-            const getBase = () => {
-                const hasSeason = /(?<![\w])(season)(?![\w])/i;
-                const hasNum = /(?<![\w])[0-9]+(?:st|[nr]d|th)(?![\w])/i;
-                const hasWord = /(?<![\w])(first|second|third|fourth|fifth|(the final|final))(?![\w])/i;
-                const hasPart = /(?<![\w])(part )/i;
-                const hasEndPunc = /[?!.]$/;
+        queryType == 'fuzzy' && (query = titleJap);
+        return query;
+    }
+}
 
-                if (baseJap.includes(': ') || baseJap.includes(' - ')) {
-                    baseJap.includes(': ') && (baseJap = baseJap.split(': ').shift());
-                    baseJap.includes(' - ') && (baseJap = baseJap.split(' - ').pop());
-                } else {
-                    if (hasSeason.test(baseJap)) {
-                        if (hasNum.test(baseJap) || hasWord.test(baseJap)) {
-                            let japNum, japWord;
-                            hasNum.test(baseJap) && (japNum = baseJap.match(hasNum)[0]);
-                            hasWord.test(baseJap) && (japWord = baseJap.match(hasWord)[0]);
-                            japNum && (baseJap = baseJap.split(` ${japNum}`).shift());
-                            japWord && (baseJap = baseJap.split(` ${japWord}`).shift());
-                        } else {
-                            baseJap = baseJap.split(/( season)/i).shift();
-                        }
-                    } else if (hasPart.test(baseJap)) {
-                        baseJap = baseJap.split(/( part)/i).shift();
-                    } else if (hasEndPunc.test(baseJap)) {
-                        let japEndPunc = baseJap.match(hasEndPunc)[0];
-                        baseJap = baseJap.split(japEndPunc).shift();
-                    }
+function getBaseTitle(baseTitle) {
+    const hasSeason = /(?<![\w])(season)(?![\w])/i;
+    const hasNum = /(?<![\w])[0-9]+(?:st|[nr]d|th)(?![\w])/i;
+    const hasWord = /(?<![\w])(first|second|third|fourth|fifth|(the final|final))(?![\w])/i;
+    const hasPart = /(?<![\w])(part )/i;
+    const hasEndPunc = /[?!.]$/;
+
+    baseTitle.includes(': ') && (baseTitle = baseTitle.split(': ').shift());
+    baseTitle.includes(' - ') && (baseTitle = baseTitle.split(' - ').pop());
+    hasPart.test(baseTitle) && (baseTitle = baseTitle.split(/( part)/i).shift());
+
+    if (hasSeason.test(baseTitle)) {
+        if (hasNum.test(baseTitle) || hasWord.test(baseTitle)) {
+            let titleNum, titleWord;
+            hasNum.test(baseTitle) && (titleNum = baseTitle.match(hasNum)[0]);
+            hasWord.test(baseTitle) && (titleWord = baseTitle.match(hasWord)[0]);
+            titleNum && (baseTitle = baseTitle.split(` ${titleNum}`).shift());
+            titleWord && (baseTitle = baseTitle.split(` ${titleWord}`).shift());
+        } else {
+            baseTitle = baseTitle.split(/( season)/i).shift();
+        }
+    }
+
+    while (hasEndPunc.test(baseTitle)) {
+        baseTitle = baseTitle.split(baseTitle.match(hasEndPunc)[0]).shift();
+    }
+
+    return baseTitle;
+}
+
+const awaitLoadOf = (selector, text, func) => {
+    return new Promise((resolve) => {
+        const mutObs = new MutationObserver(() => {
+            const elms = document.querySelectorAll(selector);
+            elms.forEach((elm) => {
+                if (elm.textContent.includes(text)) {
+                    resolve(elm);
+                    mutObs.disconnect();
+                    func();
                 }
-
-                if (baseEng.includes(': ') || baseEng.includes(' - ')) {
-                    baseEng.includes(': ') && (baseEng = baseEng.split(': ').shift());
-                    baseEng.includes(' - ') && (baseEng = baseEng.split(' - ').pop());
-                } else {
-                    if (hasSeason.test(baseEng)) {
-                        if (hasNum.test(baseEng) || hasWord.test(baseEng)) {
-                            let engNum, engWord;
-                            hasNum.test(baseEng) && (engNum = baseEng.match(hasNum)[0]);
-                            hasWord.test(baseEng) && (engWord = baseEng.match(hasWord)[0]);
-                            engNum && (baseEng = baseEng.split(` ${engNum}`).shift());
-                            engWord && (baseEng = baseEng.split(` ${engWord}`).shift());
-                        } else {
-                            baseEng = baseEng.split(/( season)/i).shift();
-                        }
-                    } else if (hasPart.test(baseEng)) {
-                        baseEng = baseEng.split(/( part)/i).shift();
-                    } else if (hasEndPunc.test(baseEng)) {
-                        let engEndPunc = baseEng.match(hasEndPunc)[0];
-                        baseEng = baseEng.split(engEndPunc).shift();
-                    }
-                }
-            };
-
-            if (!titleEng || titleJap.toLowerCase() === titleEng.toLowerCase()) {
-                query = titleJap;
-            } else {
-                getBase();
-
-                switch (queryType) {
-                    case 'default':
-                        if (baseJap == titleJap && baseEng == titleEng) {
-                            break;
-                        } else {
-                            query = `"${titleJap}"|"${titleEng}"|"${baseJap}"|"${baseEng}"`;
-                        }
-                        break;
-                    case 'fuzzy':
-                        query = titleJap;
-                        break;
-                    case 'exact':
-                        break;
-                    case 'base':
-                        if (baseJap == baseEng) {
-                            break;
-                        } else {
-                            query = `"${baseJap}"|"${baseEng}"`;
-                        }
-                        break;
-                }
-            }
-
-            if (btn) {
-                !btn.title && (btn.textContent = 'Search on Nyaa');
-                btn.href = `https://nyaa.si/?f=${filter}&c=${category}&q=${query}&s=${sort}&o=${order}`;
-                btn.target = '_blank';
-            }
+            });
         });
+        mutObs.observe(document.body, { childList: true, subtree: true });
     });
 };
-
-searchNyaa();

--- a/src/manifest-chrome.json
+++ b/src/manifest-chrome.json
@@ -1,6 +1,6 @@
 {
     "name": "Nyaa Linker",
-    "version": "1.3.0",
+    "version": "2.0.0",
     "description": "Adds a button to Anime and Manga database websites that opens a relevant Nyaa search",
     "manifest_version": 3,
 

--- a/src/manifest-firefox.json
+++ b/src/manifest-firefox.json
@@ -1,6 +1,6 @@
 {
     "name": "Nyaa Linker",
-    "version": "1.3.0",
+    "version": "2.0.0",
     "description": "Adds a button to Anime and Manga database websites that opens a relevant Nyaa search",
     "manifest_version": 2,
 

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -1,6 +1,6 @@
 :root {
     --clrDark: hsl(0, 0%, 10%);
-    --clrLight: hsl(0, 0%, 75%);
+    --clrLight: hsl(0, 0%, 87%);
     --clrAccent: hsl(210, 100%, 60%);
 }
 
@@ -20,24 +20,68 @@ body {
     width: max-content;
 }
 
-.container {
+button,
+input,
+select {
+    cursor: pointer;
+}
+
+select,
+#saveButton,
+#hotkey_key_select {
+    background: var(--clrAccent);
+    color: var(--clrDark);
+}
+
+option,
+#settingsPage {
+    background-color: var(--clrDark);
+    color: var(--clrAccent);
+}
+
+#bottomButtons {
+    display: flex;
+    gap: 2px;
+}
+
+#saveButton {
+    flex: 13;
+}
+
+#settingsButton {
+    background: var(--clrAccent) url('https://upload.wikimedia.org/wikipedia/commons/5/58/Ic_settings_48px.svg') no-repeat 0 0 / contain;
+    flex: 1;
+}
+
+#parametersPage {
     display: grid;
+    margin: 2px 0 2px 2px;
+}
+
+#parametersPage,
+#settingsPage {
     grid-template-columns: max-content max-content;
-    grid-gap: 2px;
-    margin: 2px 0 5px 2px;
+    gap: 2px;
     text-align: right;
 }
 
-select {
-    background: var(--clrAccent);
-    color: var(--clrDark);
-    margin-right: 2px;
-    text-indent: 2px;
+#settingsPage {
+    display: none;
+    border: 1px solid var(--clrAccent);
+    position: fixed;
+    padding: 5px 25px;
+    top: 0;
+    left: 0;
     width: 100%;
+    height: 85%;
 }
 
-#save {
-    background: var(--clrAccent);
-    color: var(--clrDark);
-    width: 100%;
+#hide_button_select,
+#hotkey_key_select,
+#focus_select {
+    width: 24px;
+    height: 24px;
+    text-align: center;
+    align-self: center;
+    justify-self: left;
 }

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -10,7 +10,7 @@
     </head>
 
     <body>
-        <div class="container">
+        <div id="parametersPage">
             <label for="filter_select">Filter:</label>
             <select id="filter_select">
                 <option value="0">No Filter</option>
@@ -51,6 +51,29 @@
             </select>
 
         </div>
-        <button id="save">Save</button>
-    </body>
+        <div id="bottomButtons">
+            <button id="saveButton">Save</button>
+            <button id="settingsButton"></button>
+        </div>
+
+        <div id="settingsPage">
+                <label for="hide_button_select">Hide Button:</label>
+                <input type="checkbox" id="hide_button_select" title="Stops the 'Search on Nyaa' buttom from being rendered">
+
+                <label for="focus_select">Maintain Focus:</label>
+                <input type="checkbox" id="focus_select" title="Changes Tab Focus behavior when using the Hotkey">
+                
+                <label for="hotkey_key_select">Hotkey:</label>
+                <input type="text" maxlength="1" placeholder="?" id="hotkey_key_select">
+                
+                <label for="hotkey_modifier_select">Modifier Key:</label>
+                <select id="hotkey_modifier_select">
+                    <option value="">None</option>
+                    <option value="shiftKey">Shift</option>
+                    <option value="ctrlKey">Control</option>
+                    <option value="altKey">Alt</option>
+                </select>
+
+        </div>
 </html>
+

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -6,6 +6,10 @@ window.onload = () => {
             document.getElementById('query_select').value = load.settings.query_setting;
             document.getElementById('sort_select').value = load.settings.sort_setting;
             document.getElementById('order_select').value = load.settings.order_setting;
+            document.getElementById('hide_button_select').checked = load.settings.hide_button_setting;
+            document.getElementById('focus_select').checked = load.settings.focus_setting;
+            document.getElementById('hotkey_key_select').value = load.settings.hotkey_key_setting;
+            document.getElementById('hotkey_modifier_select').value = load.settings.hotkey_modifier_setting;
         }
     });
 };
@@ -17,10 +21,19 @@ const saveSettings = () => {
     settings['query_setting'] = document.getElementById('query_select').value;
     settings['sort_setting'] = document.getElementById('sort_select').value;
     settings['order_setting'] = document.getElementById('order_select').value;
+    settings['hide_button_setting'] = document.getElementById('hide_button_select').checked;
+    settings['focus_setting'] = document.getElementById('focus_select').checked;
+    settings['hotkey_key_setting'] = document.getElementById('hotkey_key_select').value.toLowerCase();
+    settings['hotkey_modifier_setting'] = document.getElementById('hotkey_modifier_select').value;
     return settings;
 };
 
-document.getElementById('save').onclick = () => {
+document.getElementById('settingsButton').onclick = () => {
+    let settingsPopup = document.getElementById('settingsPage');
+    settingsPopup.style.display !== 'grid' ? (settingsPopup.style.display = 'grid') : (settingsPopup.style.display = 'none');
+};
+
+document.getElementById('saveButton').onclick = () => {
     chrome.storage.sync.set({ settings: saveSettings() });
     chrome.tabs.query({}, (tabs) => {
         const manifestSites = chrome.runtime.getManifest().content_scripts[0].matches;


### PR DESCRIPTION
**refactored** the codebase
- reduced the number of nested functions and limited the maximum nesting level
- made the query creation functions modular instead of writing them twice for Jap & Eng
- "awaitLoadOf" now properly targets the required title info, instead of just reloading until it works
- _these changes about as close to "breaking" as this type of program can get; updating to v2.0.0_

**added** a secondary settings page, accessible by clicking the cog icon within popup.html
- added an option to not render the "Search on Nyaa" button
- added a _customizable_ hotkey that will open the search when pressed _(even if the button is hidden)_
	- _on card-type pages this only opens the first link; any attempt to allow batch openings just resulted in HTTP "429 Too Many Requests" errors for most of the pages, and using delays just made it super awkward_
- added an option to change the tab focus behavior when using the hotkey
	- _enabled = focus stays on the current tab **|** disabled = changes focus to the Nyaa tab_

**fixed** MAL card-type pages to allow for multiple titles _(I incorrectly thought there could only be one title per card)_
**fixed** issues with the button not rendering on Kitsu depending on the user's login state
**fixed** errors on AniDB and Anime-Planet for non-series pages that start with /anime/ or /manga/

**updated** README.md
- updated the banner image; more uniform sizes with better separation, and different shows for each site: [old](https://i.imgur.com/MVR68qM.jpeg) | [new](https://i.imgur.com/DXMg8ha.png)
- updated the extension popup screenshot to show the updated functionality
- updated the site preview images to show more of the website instead of just the panels
	- added additional site previews for the newly supported card-type pages