### PR TITLE
add: hotkey-query-selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 -   Adds a "Search on Nyaa" Button to Anime and Manga database pages
     -   Individual: **[MyAnimeList](https://i.imgur.com/IXJ7XuK.png), [AniList](https://i.imgur.com/9xhFu5q.jpeg), [Anime-Planet](https://i.imgur.com/sGsl0Bw.png), [AnimeNewsNetwork](https://i.imgur.com/xXvJXHC.png), [LiveChart](https://i.imgur.com/VyIWtLC.png), [AniDB](https://i.imgur.com/DqSkmOg.jpeg), [Kitsu](https://i.imgur.com/CN2kh4C.jpeg)**
     -   Card-type: _**MyAnimeList** ([Season](https://i.imgur.com/7M4hr0z.png), [Genre](https://i.imgur.com/SklbImH.png)), **LiveChart** ([Season](https://i.imgur.com/wvLOp8N.jpeg), [Franchises](https://i.imgur.com/wcNv1JC.jpeg))_
--   Extension settings can be customized and saved in the [Extension Popup window](https://i.imgur.com/ymIkV63.png)
+-   Extension settings can be customized and saved in the [Extension Popup window](https://i.imgur.com/Ezz4S6x.png)
 
     -   The primary settings page is used to change Nyaa search parameters
         -   For Manga pages, the Category setting will search for the "Literature" equivalent

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nyaa-linker",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "Adds a button to Anime and Manga database websites that opens a relevant Nyaa search",
     "scripts": {
         "zip": "npm run firefox && npm run chrome",

--- a/src/background.js
+++ b/src/background.js
@@ -21,6 +21,7 @@ const defaultSettings = () => {
             focus_setting: false,
             hotkey_key_setting: '',
             hotkey_modifier_setting: '',
+            hotkey_query_setting: 'inherit',
         },
     });
 };

--- a/src/manifest-chrome.json
+++ b/src/manifest-chrome.json
@@ -1,6 +1,6 @@
 {
     "name": "Nyaa Linker",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "Adds a button to Anime and Manga database websites that opens a relevant Nyaa search",
     "manifest_version": 3,
 

--- a/src/manifest-firefox.json
+++ b/src/manifest-firefox.json
@@ -1,6 +1,6 @@
 {
     "name": "Nyaa Linker",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "Adds a button to Anime and Manga database websites that opens a relevant Nyaa search",
     "manifest_version": 2,
 

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -18,12 +18,32 @@ body {
     background: var(--clrDark);
     color: var(--clrLight);
     width: max-content;
+    font-family: sans-serif;
+}
+
+#parametersPage,
+#settingsPage {
+    display: grid;
+    grid-template-columns: max-content max-content;
+    gap: 2px;
+    padding: 2px 0 2px 2px;
+    text-align: right;
+}
+
+#settingsPage {
+    display: none;
+    border: 1px solid var(--clrAccent);
+    border-top: none;
+    padding-left: 25px;
 }
 
 button,
 input,
-select {
+select,
+option {
     cursor: pointer;
+    text-align: center;
+    height: 21px;
 }
 
 select,
@@ -35,7 +55,7 @@ select,
 
 option,
 #settingsPage {
-    background-color: var(--clrDark);
+    background: var(--clrDark);
     color: var(--clrAccent);
 }
 
@@ -45,7 +65,7 @@ option,
 }
 
 #saveButton {
-    flex: 13;
+    flex: 11;
 }
 
 #settingsButton {
@@ -53,35 +73,13 @@ option,
     flex: 1;
 }
 
-#parametersPage {
-    display: grid;
-    margin: 2px 0 2px 2px;
-}
-
-#parametersPage,
-#settingsPage {
-    grid-template-columns: max-content max-content;
-    gap: 2px;
-    text-align: right;
-}
-
-#settingsPage {
-    display: none;
-    border: 1px solid var(--clrAccent);
-    position: fixed;
-    padding: 5px 25px;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 85%;
-}
-
-#hide_button_select,
 #hotkey_key_select,
-#focus_select {
-    width: 24px;
-    height: 24px;
-    text-align: center;
-    align-self: center;
+input[type='checkbox'] {
+    width: 21px;
     justify-self: left;
+}
+
+#hotkey_modifier_select,
+#hotkey_query_select {
+    width: 150%;
 }

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -58,7 +58,7 @@
 
         <div id="settingsPage">
                 <label for="hide_button_select">Hide Button:</label>
-                <input type="checkbox" id="hide_button_select" title="Stops the 'Search on Nyaa' buttom from being rendered">
+                <input type="checkbox" id="hide_button_select" title="Stops the 'Search on Nyaa' button from being rendered">
 
                 <label for="focus_select">Maintain Focus:</label>
                 <input type="checkbox" id="focus_select" title="Changes Tab Focus behavior when using the Hotkey">
@@ -66,12 +66,21 @@
                 <label for="hotkey_key_select">Hotkey:</label>
                 <input type="text" maxlength="1" placeholder="?" id="hotkey_key_select">
                 
-                <label for="hotkey_modifier_select">Modifier Key:</label>
+                <label for="hotkey_modifier_select">Hotkey Modifier:</label>
                 <select id="hotkey_modifier_select">
                     <option value="">None</option>
                     <option value="shiftKey">Shift</option>
                     <option value="ctrlKey">Control</option>
                     <option value="altKey">Alt</option>
+                </select>
+                
+                <label for="hotkey_query_select">Hotkey Query:</label>
+                <select id="hotkey_query_select">
+                    <option value="inherit" title="Inherits its behavior from the Query option on the primary settings page">Inherit</option>
+                    <option value="default" title="Creates a search using both the 'Exact' and 'Base' options">Default</option>
+                    <option value="fuzzy" title="Searches for the site's default title only, without quotes — allows fuzzy matching">Fuzzy</option>
+                    <option value="exact" title="Japanese and English full titles — searches for exact title names as written">Exact</option>
+                    <option value="base" title="Japanese and English base titles — searches with Seasons and Parts removed">Base</option>
                 </select>
 
         </div>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -10,6 +10,7 @@ window.onload = () => {
             document.getElementById('focus_select').checked = load.settings.focus_setting;
             document.getElementById('hotkey_key_select').value = load.settings.hotkey_key_setting;
             document.getElementById('hotkey_modifier_select').value = load.settings.hotkey_modifier_setting;
+            document.getElementById('hotkey_query_select').value = load.settings.hotkey_query_setting;
         }
     });
 };
@@ -25,6 +26,7 @@ const saveSettings = () => {
     settings['focus_setting'] = document.getElementById('focus_select').checked;
     settings['hotkey_key_setting'] = document.getElementById('hotkey_key_select').value.toLowerCase();
     settings['hotkey_modifier_setting'] = document.getElementById('hotkey_modifier_select').value;
+    settings['hotkey_query_setting'] = document.getElementById('hotkey_query_select').value;
     return settings;
 };
 


### PR DESCRIPTION
- added an additional "Query" option in the secondary options page, for use with the Hotkey 
	- _this allows for scenarios such as: using the Hotkey/Button to do a 'Default' search, and then being able to use the other for a 'Fuzzy' search, allowing for a quick fuzzy search for shows with abnormal titles (see #6 for more details)_
	- _this option is set to "Inherit" by default, which just copies the Query selection from the primary settings page_
- removed Hotkey functionality from card-type pages
	- _the Hotkey only ever worked for the first card on the page, as is explained in #9, and since the new query selector wouldn't work with it either, I've decided to just disable the functionality since it was basically useless_
- fixed an issue on MAL card-type pages where soft reloading the page _(such as using the backward/forward buttons, or adding a show to your watchlist)_ would [create a new button each time](https://i.imgur.com/An6uqWQ.jpeg)
- fixed an issue on AniList/Kitsu where the extension would reinitialize each time a sub page was loaded
- fixed an issue on AniList/ANN where the "Hide Button" option wasn't working