### PR TITLE
fix: special-title-characters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nyaa-linker",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "description": "Adds a button to Anime and Manga database websites that opens a relevant Nyaa search",
     "scripts": {
         "zip": "npm run firefox && npm run chrome",

--- a/src/main.js
+++ b/src/main.js
@@ -42,6 +42,7 @@ function searchNyaa(settings) {
 
     function createSearch(query) {
         !btn.title && (btn.textContent = 'Search on Nyaa');
+        (query.includes('&') || query.includes('+')) && (query = query.replace(/&/g, '%26').replace(/\+/g, '%2B'));
         btn.href = `https://nyaa.si/?f=${settings.filter_setting}&c=${settings.category_setting}&q=${query}&s=${settings.sort_setting}&o=${settings.order_setting}`;
         btn.target = '_blank';
     }
@@ -193,7 +194,7 @@ function searchNyaa(settings) {
             });
             break;
 
-        case domain.includes(`kitsu.io/${media}/`):
+        case domain.includes(`kitsu.app/${media}/`):
             awaitLoadOf('.media--information', 'Japanese (Romaji)', () => {
                 let titleUsa;
                 for (const typeCheck of document.querySelectorAll('.media--information > ul > li')) {

--- a/src/manifest-chrome.json
+++ b/src/manifest-chrome.json
@@ -1,6 +1,6 @@
 {
     "name": "Nyaa Linker",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "description": "Adds a button to Anime and Manga database websites that opens a relevant Nyaa search",
     "manifest_version": 3,
 
@@ -10,7 +10,7 @@
             "matches": [
                 "*://*.myanimelist.net/*",
                 "*://*.anilist.co/*",
-                "*://*.kitsu.io/*",
+                "*://*.kitsu.app/*",
                 "*://*.anime-planet.com/*",
                 "*://*.animenewsnetwork.com/encyclopedia/*",
                 "*://*.anidb.net/*",

--- a/src/manifest-firefox.json
+++ b/src/manifest-firefox.json
@@ -1,6 +1,6 @@
 {
     "name": "Nyaa Linker",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "description": "Adds a button to Anime and Manga database websites that opens a relevant Nyaa search",
     "manifest_version": 2,
 
@@ -10,7 +10,7 @@
             "matches": [
                 "*://*.myanimelist.net/*",
                 "*://*.anilist.co/*",
-                "*://*.kitsu.io/*",
+                "*://*.kitsu.app/*",
                 "*://*.anime-planet.com/*",
                 "*://*.animenewsnetwork.com/encyclopedia/*",
                 "*://*.anidb.net/*",


### PR DESCRIPTION
- changed kitsu.io to kitsu.app to match their new domain
- fixed an issue where some special characters would break the search when present in the title
    - titles with the '&' symbol would end the search right before the symbol
        - https://myanimelist.net/anime/14741/Chuunibyou_demo_Koi_ga_Shitai
        - https://myanimelist.net/anime/57864/Monogatari_Series__Off___Monster_Season
    - titles with the '+' symbol would finish the search, but would replace '+' with a blank space
        - https://myanimelist.net/anime/2993/Rosario_to_Vampire
        - https://myanimelist.net/anime/150/Blood_