### PR TITLE
add: custom-query-text

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 -   Adds a "Search on Nyaa" Button to Anime and Manga database pages
     -   Individual: **[MyAnimeList](https://i.imgur.com/IXJ7XuK.png), [AniList](https://i.imgur.com/9xhFu5q.jpeg), [Anime-Planet](https://i.imgur.com/sGsl0Bw.png), [AnimeNewsNetwork](https://i.imgur.com/xXvJXHC.png), [LiveChart](https://i.imgur.com/VyIWtLC.png), [AniDB](https://i.imgur.com/DqSkmOg.jpeg), [Kitsu](https://i.imgur.com/CN2kh4C.jpeg)**
     -   Card-type: _**MyAnimeList** ([Season](https://i.imgur.com/7M4hr0z.png), [Genre](https://i.imgur.com/SklbImH.png)), **LiveChart** ([Season](https://i.imgur.com/wvLOp8N.jpeg), [Franchises](https://i.imgur.com/wcNv1JC.jpeg))_
--   Extension settings can be customized and saved in the [Extension Popup window](https://i.imgur.com/Ezz4S6x.png)
+-   Extension settings can be customized and saved in the [Extension Popup window](https://i.imgur.com/a/cRBmW3T)
 
     -   The primary settings page is used to change Nyaa search parameters
         -   For Manga pages, the Category setting will search for the "Literature" equivalent

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
     "name": "nyaa-linker",
-    "version": "2.1.1",
+    "version": "2.2.0",
     "description": "Adds a button to Anime and Manga database websites that opens a relevant Nyaa search",
     "scripts": {
         "zip": "npm run firefox && npm run chrome",
-        "firefox": "mv src/manifest-firefox.json src/manifest.json && cd src && 7z a ..\\nyaa-linker-%npm_package_version%-%npm_lifecycle_event%.zip * -r -x!manifest-*.json && cd .. && mv src/manifest.json src/manifest-firefox.json",
-        "chrome": "mv src/manifest-chrome.json src/manifest.json && cd src && 7z a ..\\nyaa-linker-%npm_package_version%-%npm_lifecycle_event%.zip * -r -x!manifest-*.json && cd .. && mv src/manifest.json src/manifest-chrome.json"
+        "firefox": "mv src/manifest-firefox.json src/manifest.json && cd src && zip -r ../nyaa-linker-$npm_package_version-$npm_lifecycle_event.zip . -x 'manifest-*.json' && cd .. && mv src/manifest.json src/manifest-firefox.json",
+        "chrome": "mv src/manifest-chrome.json src/manifest.json && cd src && zip -r ../nyaa-linker-$npm_package_version-$npm_lifecycle_event.zip . -x 'manifest-*.json' && cd .. && mv src/manifest.json src/manifest-chrome.json"
     },
     "devDependencies": {
         "eslint": "^8.26.0",

--- a/src/background.js
+++ b/src/background.js
@@ -19,6 +19,8 @@ const defaultSettings = () => {
             order_setting: 'desc',
             hide_button_setting: false,
             focus_setting: false,
+            custom_text_toggle_setting: false,
+            custom_text_setting: '',
             hotkey_key_setting: '',
             hotkey_modifier_setting: '',
             hotkey_query_setting: 'inherit',

--- a/src/main.js
+++ b/src/main.js
@@ -23,6 +23,7 @@ function searchNyaa(settings) {
     const media = window.location.pathname.includes('manga') ? 'manga' : 'anime';
     let titleJap, titleEng, btnSpace, cardType, cardFlag;
     let queryType = settings.query_setting;
+    let customQuery = settings.custom_text_toggle_setting ? settings.custom_text_setting : '';
 
     if (media === 'manga') {
         const searchManga = (cat) => {
@@ -43,7 +44,7 @@ function searchNyaa(settings) {
     function createSearch(query) {
         !btn.title && (btn.textContent = 'Search on Nyaa');
         (query.includes('&') || query.includes('+')) && (query = query.replace(/&/g, '%26').replace(/\+/g, '%2B'));
-        btn.href = `https://nyaa.si/?f=${settings.filter_setting}&c=${settings.category_setting}&q=${query}&s=${settings.sort_setting}&o=${settings.order_setting}`;
+        btn.href = `https://nyaa.si/?f=${settings.filter_setting}&c=${settings.category_setting}&q=${query}${customQuery}&s=${settings.sort_setting}&o=${settings.order_setting}`;
         btn.target = '_blank';
     }
 
@@ -248,6 +249,8 @@ function searchNyaa(settings) {
 
 function getQuery(titleJap, titleEng, queryType) {
     !titleJap && !titleEng && init();
+    titleJap && (titleJap = titleJap.replace(/["]/g, ''));
+    titleEng && (titleEng = titleEng.replace(/["]/g, ''));
     query = `"${titleJap}"|"${titleEng}"`;
 
     if (!titleEng || titleJap.toLowerCase() === titleEng.toLowerCase()) {
@@ -276,6 +279,12 @@ function getBaseTitle(baseTitle) {
     const hasWord = /(?<![\w])(first|second|third|fourth|fifth|(the final|final))(?![\w])/i;
     const hasPart = /(?<![\w])(part )/i;
     const hasEndPunc = /[?!.]$/;
+
+    baseTitle = baseTitle
+        .replace(/[\(\)\[\]\{\}][^()\[\]\{\}]*[\)\]\{\}]/g, '')
+        .replace(/([♡♥☆★♪∞])(?=\w)/g, ' ')
+        .replace(/[♡♥☆★♪∞](?!\w)/g, '')
+        .trim();
 
     baseTitle.includes(': ') && (baseTitle = baseTitle.split(': ').shift());
     baseTitle.includes(' - ') && (baseTitle = baseTitle.split(' - ').pop());

--- a/src/manifest-chrome.json
+++ b/src/manifest-chrome.json
@@ -1,6 +1,6 @@
 {
     "name": "Nyaa Linker",
-    "version": "2.1.1",
+    "version": "2.2.0",
     "description": "Adds a button to Anime and Manga database websites that opens a relevant Nyaa search",
     "manifest_version": 3,
 

--- a/src/manifest-firefox.json
+++ b/src/manifest-firefox.json
@@ -1,6 +1,6 @@
 {
     "name": "Nyaa Linker",
-    "version": "2.1.1",
+    "version": "2.2.0",
     "description": "Adds a button to Anime and Manga database websites that opens a relevant Nyaa search",
     "manifest_version": 2,
 

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -15,16 +15,17 @@
 }
 
 body {
+    font-family: sans-serif;
     background: var(--clrDark);
     color: var(--clrLight);
-    width: max-content;
-    font-family: sans-serif;
+    width: min-content;
+    overflow: hidden;
 }
 
 #parametersPage,
 #settingsPage {
     display: grid;
-    grid-template-columns: max-content max-content;
+    grid-template-columns: auto auto;
     gap: 2px;
     padding: 2px 0 2px 2px;
     text-align: right;
@@ -48,7 +49,8 @@ option {
 
 select,
 #saveButton,
-#hotkey_key_select {
+#hotkey_key_select,
+#custom_text_select {
     background: var(--clrAccent);
     color: var(--clrDark);
 }
@@ -80,6 +82,7 @@ input[type='checkbox'] {
 }
 
 #hotkey_modifier_select,
-#hotkey_query_select {
-    width: 150%;
+#hotkey_query_select,
+#custom_text_select {
+    width: 98%;
 }

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -63,6 +63,12 @@
                 <label for="focus_select">Maintain Focus:</label>
                 <input type="checkbox" id="focus_select" title="Changes Tab Focus behavior when using the Hotkey">
                 
+                <label for="custom_text_toggle_select">Include Text:</label>
+                <input type="checkbox" id="custom_text_toggle_select" title="Decides if text in 'Custom Query' is included">
+                
+                <label for="custom_text_select">Custom Text:</label>
+                <input type="text" placeholder="?" id="custom_text_select" title="User defined text to be added at the end of the search query">
+                
                 <label for="hotkey_key_select">Hotkey:</label>
                 <input type="text" maxlength="1" placeholder="?" id="hotkey_key_select">
                 
@@ -81,8 +87,7 @@
                     <option value="fuzzy" title="Searches for the site's default title only, without quotes — allows fuzzy matching">Fuzzy</option>
                     <option value="exact" title="Japanese and English full titles — searches for exact title names as written">Exact</option>
                     <option value="base" title="Japanese and English base titles — searches with Seasons and Parts removed">Base</option>
-                </select>
-
+                </select>              
         </div>
 </html>
 

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -8,6 +8,8 @@ window.onload = () => {
             document.getElementById('order_select').value = load.settings.order_setting;
             document.getElementById('hide_button_select').checked = load.settings.hide_button_setting;
             document.getElementById('focus_select').checked = load.settings.focus_setting;
+            document.getElementById('custom_text_toggle_select').checked = load.settings.custom_text_toggle_setting;
+            document.getElementById('custom_text_select').value = load.settings.custom_text_setting;
             document.getElementById('hotkey_key_select').value = load.settings.hotkey_key_setting;
             document.getElementById('hotkey_modifier_select').value = load.settings.hotkey_modifier_setting;
             document.getElementById('hotkey_query_select').value = load.settings.hotkey_query_setting;
@@ -24,6 +26,8 @@ const saveSettings = () => {
     settings['order_setting'] = document.getElementById('order_select').value;
     settings['hide_button_setting'] = document.getElementById('hide_button_select').checked;
     settings['focus_setting'] = document.getElementById('focus_select').checked;
+    settings['custom_text_toggle_setting'] = document.getElementById('custom_text_toggle_select').checked;
+    settings['custom_text_setting'] = document.getElementById('custom_text_select').value;
     settings['hotkey_key_setting'] = document.getElementById('hotkey_key_select').value.toLowerCase();
     settings['hotkey_modifier_setting'] = document.getElementById('hotkey_modifier_select').value;
     settings['hotkey_query_setting'] = document.getElementById('hotkey_query_select').value;


### PR DESCRIPTION
**added** custom query text
- adds additional text after the generated query
- e.g. ` SubsPlease 1080p` using `Default` search on [Attack on Titan](https://myanimelist.net/anime/16498/Shingeki_no_Kyojin), would be:
	- **"Shingeki no Kyojin"|"Attack on Titan" SubsPlease 1080p**
- the custom text will add exactly what is entered: `SubsPlease`, `   SubsPlease`, and `|"SubsPlease"` are all different
- additionally added a toggle so you don't have to delete your custom text, while still being able to search without it

**fixed** search issues for titles containing advanced special characters _(♡♥☆★♪∞)_
- this activates as part of the "Base" title converter; if using "Fuzzy" search this wasn't really a problem
- 'unique' characters used for 1 series weren't included, e.g: [Yuru Camp△](https://myanimelist.net/anime/34798/Yuru_Camp%E2%96%B3), [Saiki Kusuo no Ψ-nan](https://myanimelist.net/anime/33255/Saiki_Kusuo_no_%CE%A8-nan), [∀ Gundam](https://myanimelist.net/anime/95/Turn_A_Gundam), etc

**fixed** search issues for titles containing certain delimiter characters, such as: _`(), [], {}, ""`_
- Oshi no Ko is an example that _(used to?)_ contains multiple; `[]` for the English title, and `""` for the Japanese title
- quotation marks would break the entire search, effectively nullifying most search terms