### PR TITLE
add: sukebei-support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nyaa-linker",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "description": "Adds a button to Anime and Manga database websites that opens a relevant Nyaa search",
     "scripts": {
         "zip": "npm run firefox && npm run chrome",

--- a/src/manifest-chrome.json
+++ b/src/manifest-chrome.json
@@ -1,6 +1,6 @@
 {
     "name": "Nyaa Linker",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "description": "Adds a button to Anime and Manga database websites that opens a relevant Nyaa search",
     "manifest_version": 3,
 

--- a/src/manifest-firefox.json
+++ b/src/manifest-firefox.json
@@ -1,6 +1,6 @@
 {
     "name": "Nyaa Linker",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "description": "Adds a button to Anime and Manga database websites that opens a relevant Nyaa search",
     "manifest_version": 2,
 


### PR DESCRIPTION
**added** support for Nyaa's Sukebei sub-domain
- works best on MyAnimeList 
	- _(Anime-Planet, LiveChart, and ANN entirely ban Hentai, and thus have zero functionality)_
	- _(AniDB, AniList, and Kitsu have visibility restrictions, AniDB and AniList should be fully functional, while Kitsu doesn't have a reliable way to check for R18 Literature, so only Anime will work.)_
- checks if the specific page has a 'Hentai'-type tag, and then replaces 'Nyaa' with 'Sukebei'
- non-anime searches on Sukebei will use the 'All' category, to simplify source type

closes #14